### PR TITLE
Targeted iOS v8.0

### DIFF
--- a/Just.xcodeproj/project.pbxproj
+++ b/Just.xcodeproj/project.pbxproj
@@ -7,13 +7,13 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		872136D81B288923003BA8CA /* Just-iOS.h in Headers */ = {isa = PBXBuildFile; fileRef = 872136D71B288923003BA8CA /* Just-iOS.h */; };
 		940C09D71AF41B1200E6F7B9 /* Nimble.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 94481BE31AF4142F00C34129 /* Nimble.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		940C09D81AF41B1200E6F7B9 /* Quick.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 94481BE41AF4142F00C34129 /* Quick.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		940C09DA1AF41B4E00E6F7B9 /* Nimble.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 94DA2B791AE642FB0082DC6D /* Nimble.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		940C09DB1AF41B4E00E6F7B9 /* Quick.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 94DA2B7A1AE642FB0082DC6D /* Quick.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		94481BE71AF4155A00C34129 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 94481BE31AF4142F00C34129 /* Nimble.framework */; };
 		94481BE81AF4155D00C34129 /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 94481BE41AF4142F00C34129 /* Quick.framework */; };
-		948CA8221AF3FF43001E0FD3 /* Just-iOS.h in Headers */ = {isa = PBXBuildFile; fileRef = 948CA8211AF3FF43001E0FD3 /* Just-iOS.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		948CA8281AF3FF43001E0FD3 /* Just.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 948CA81D1AF3FF43001E0FD3 /* Just.framework */; };
 		948CA8401AF3FF55001E0FD3 /* Just-OSX.h in Headers */ = {isa = PBXBuildFile; fileRef = 948CA83F1AF3FF55001E0FD3 /* Just-OSX.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		948CA8461AF3FF55001E0FD3 /* Just.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 948CA83B1AF3FF55001E0FD3 /* Just.framework */; };
@@ -73,12 +73,12 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		872136D71B288923003BA8CA /* Just-iOS.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "Just-iOS.h"; path = "Just/Just-iOS/Just-iOS.h"; sourceTree = SOURCE_ROOT; };
 		94481BE31AF4142F00C34129 /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nimble.framework; path = Carthage/Build/Mac/Nimble.framework; sourceTree = SOURCE_ROOT; };
 		94481BE41AF4142F00C34129 /* Quick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Quick.framework; path = Carthage/Build/Mac/Quick.framework; sourceTree = SOURCE_ROOT; };
 		948444A21AF29B000013B998 /* CaseInsensitiveDictionarySpecs.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CaseInsensitiveDictionarySpecs.swift; sourceTree = "<group>"; };
 		948CA81D1AF3FF43001E0FD3 /* Just.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Just.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		948CA8201AF3FF43001E0FD3 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; name = Info.plist; path = "Just/Just-iOS/Info.plist"; sourceTree = "<group>"; };
-		948CA8211AF3FF43001E0FD3 /* Just-iOS.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "Just-iOS.h"; path = "Just/Just-iOS/Just-iOS.h"; sourceTree = "<group>"; };
 		948CA8271AF3FF43001E0FD3 /* Just-iOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Just-iOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		948CA82D1AF3FF43001E0FD3 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; name = Info.plist; path = "JustTests/Just-iOSTests/Info.plist"; sourceTree = "<group>"; };
 		948CA83B1AF3FF55001E0FD3 /* Just.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Just.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -134,7 +134,7 @@
 		948CA81E1AF3FF43001E0FD3 /* Just-iOS */ = {
 			isa = PBXGroup;
 			children = (
-				948CA8211AF3FF43001E0FD3 /* Just-iOS.h */,
+				872136D71B288923003BA8CA /* Just-iOS.h */,
 				948CA81F1AF3FF43001E0FD3 /* Supporting Files */,
 			);
 			path = "Just-iOS";
@@ -252,7 +252,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				948CA8221AF3FF43001E0FD3 /* Just-iOS.h in Headers */,
+				872136D81B288923003BA8CA /* Just-iOS.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -465,6 +465,7 @@
 				);
 				INFOPLIST_FILE = "$(SRCROOT)/Just/Just-iOS/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_NAME = Just;
 				SKIP_INSTALL = YES;
@@ -480,6 +481,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = "$(SRCROOT)/Just/Just-iOS/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_NAME = Just;
 				SKIP_INSTALL = YES;


### PR DESCRIPTION
There's no reason I can see that Just needs to target 8.3, so I've flipped it to 8.0, we have a 40% non 8.3 userbase and I imagine that number is reflected in other codebases.

