### PR TITLE
Fix file upload demo URL

### DIFF
--- a/Docs/QuickStart.playground/Contents.swift
+++ b/Docs/QuickStart.playground/Contents.swift
@@ -138,7 +138,7 @@ import Foundation
 
 
 
-let elonPhotoURL = NSURL(string: NSBundle.mainBundle().pathForResource("elon", ofType: "jpg")!)! // assume the file exist
+let elonPhotoURL = NSBundle.mainBundle().URLForResource("elon", withExtension: "jpg")! // assume the file exist
 let uploadResult = Just.post("http://httpbin.org/post", files:["elon":.URL(elonPhotoURL, nil)]) // <== that's it
 print(uploadResult.text ?? "")
 


### PR DESCRIPTION
The file upload fails when the NSURL object is created through `string` instead of `fileURLWithPath`

However, this can be further simplified from:
`NSURL(fileURLWithPath: NSBundle.mainBundle().pathForResource("elon", ofType: "jpg")!)!`
to
`NSBundle.mainBundle().URLForResource("elon", withExtension: "jpg")!`
