### PR TITLE
Running the completion handler in the main thread

### DIFF
--- a/Just/Just.swift
+++ b/Just/Just.swift
@@ -902,7 +902,9 @@ public final class HTTP: NSObject, NSURLSessionDelegate, JustAdaptor {
                         progressHandler: asyncProgressHandler
                         ) { result in
                             if let handler = asyncCompletionHandler {
-                                handler(result)
+                                dispatch_async(dispatch_get_main_queue()) {
+                                    handler(result)
+                                }
                             }
                             if isSync {
                                 requestResult = result


### PR DESCRIPTION
-Doesn’t need the understanding or the use of NSOperationQueue or GCD if you need to update UI in the callback.
-Cleaner code in the swift closure if you update UI in the callback