### PR TITLE
Remove space in basic auth header

### DIFF
--- a/Sources/Just/Just.swift
+++ b/Sources/Just/Just.swift
@@ -906,7 +906,7 @@ public final class HTTP: NSObject, URLSessionDelegate, JustAdaptor {
       }
 
       if let auth = auth,
-        let utf8 = "\(auth.0): \(auth.1)".data(using: String.Encoding.utf8)
+        let utf8 = "\(auth.0):\(auth.1)".data(using: String.Encoding.utf8)
       {
         finalHeaders["Authorization"] = "Basic \(utf8.base64EncodedString())"
       }


### PR DESCRIPTION
When using basic auth a space was being added to the password. 