### PR TITLE
Add data chunk to HTTPProgress when Type == .Download 

### DIFF
--- a/Docs/QuickStart.playground/Contents.swift
+++ b/Docs/QuickStart.playground/Contents.swift
@@ -231,6 +231,7 @@ Just.post(
         p.type // either .Upload or .Download
         p.bytesProcessed
         p.bytesExpectedToProcess
+        p.chunk // present when type == .Download
         p.percent
     }
 ) { r in

--- a/Sources/Just/Just.swift
+++ b/Sources/Just/Just.swift
@@ -373,13 +373,12 @@ public struct HTTPProgress {
     return Float(bytesProcessed) / Float(bytesExpectedToProcess)
   }
 
-  init(type: Type, bytesProcessed: Int64, bytesExpectedToProcess: Int64) {
-    self.type = type
-    self.bytesProcessed = bytesProcessed
-    self.bytesExpectedToProcess = bytesExpectedToProcess
-  }
-
-  init(type: Type, bytesProcessed: Int64, bytesExpectedToProcess: Int64, chunk: Data) {
+  init(
+    type: Type,
+    bytesProcessed: Int64,
+    bytesExpectedToProcess: Int64,
+    chunk: Data? = nil)
+ {
     self.type = type
     self.bytesProcessed = bytesProcessed
     self.bytesExpectedToProcess = bytesExpectedToProcess

--- a/Sources/Just/Just.swift
+++ b/Sources/Just/Just.swift
@@ -372,18 +372,6 @@ public struct HTTPProgress {
   public var percent: Float {
     return Float(bytesProcessed) / Float(bytesExpectedToProcess)
   }
-
-  init(
-    type: Type,
-    bytesProcessed: Int64,
-    bytesExpectedToProcess: Int64,
-    chunk: Data? = nil)
- {
-    self.type = type
-    self.bytesProcessed = bytesProcessed
-    self.bytesExpectedToProcess = bytesExpectedToProcess
-    self.chunk = chunk
-  }
 }
 
 let errorDomain = "net.justhttp.Just"
@@ -1075,7 +1063,8 @@ extension HTTP: URLSessionTaskDelegate, URLSessionDataDelegate {
         HTTPProgress(
           type: .upload,
           bytesProcessed: totalBytesSent,
-          bytesExpectedToProcess: totalBytesExpectedToSend
+          bytesExpectedToProcess: totalBytesExpectedToSend,
+          chunk: nil
         )
       )
     }

--- a/Sources/Just/Just.swift
+++ b/Sources/Just/Just.swift
@@ -368,8 +368,22 @@ public struct HTTPProgress {
   public let type: Type
   public let bytesProcessed: Int64
   public let bytesExpectedToProcess: Int64
+  public var chunk: Data?
   public var percent: Float {
     return Float(bytesProcessed) / Float(bytesExpectedToProcess)
+  }
+
+  init(type: Type, bytesProcessed: Int64, bytesExpectedToProcess: Int64) {
+    self.type = type
+    self.bytesProcessed = bytesProcessed
+    self.bytesExpectedToProcess = bytesExpectedToProcess
+  }
+
+  init(type: Type, bytesProcessed: Int64, bytesExpectedToProcess: Int64, chunk: Data) {
+    self.type = type
+    self.bytesProcessed = bytesProcessed
+    self.bytesExpectedToProcess = bytesExpectedToProcess
+    self.chunk = chunk
   }
 }
 
@@ -1076,7 +1090,8 @@ extension HTTP: URLSessionTaskDelegate, URLSessionDataDelegate {
         HTTPProgress(
           type: .download,
           bytesProcessed: dataTask.countOfBytesReceived,
-          bytesExpectedToProcess: dataTask.countOfBytesExpectedToReceive
+          bytesExpectedToProcess: dataTask.countOfBytesExpectedToReceive,
+          chunk: data
         )
       )
     }


### PR DESCRIPTION
As far as I could tell, there was no way to access the data chunk being downloaded. This adds this data to HTTPProgress so it is accessible via the asyncProgressHandler.