### PR TITLE
Allow non-filename HTTPFile.text

### DIFF
--- a/Sources/Just/Just.swift
+++ b/Sources/Just/Just.swift
@@ -84,7 +84,7 @@ let statusCodeDescriptions = [
 public enum HTTPFile {
   case url(URL, String?) // URL to a file, mimetype
   case data(String, Foundation.Data, String?) // filename, data, mimetype
-  case text(String, String, String?) // filename, text, mimetype
+  case text(String?, String, String?) // filename, text, mimetype
 }
 
 // Supported request types
@@ -850,8 +850,13 @@ public final class HTTP: NSObject, URLSessionDelegate, JustAdaptor {
         partContent = data
         partMimetype = mimetype
       }
-      if let content = partContent, let filename = partFilename {
-        let dispose = "Content-Disposition: form-data; name=\"\(k)\"; filename=\"\(filename)\"\r\n"
+      if let content = partContent {
+        let dispose: String
+        if let filename = partFilename {
+          dispose = "Content-Disposition: form-data; name=\"\(k)\"; filename=\"\(filename)\"\r\n"
+        } else {
+          dispose = "Content-Disposition: form-data; name=\"\(k)\"\r\n"
+        }
         body.append(dispose.data(using: defaults.encoding)!)
         if let type = partMimetype {
           body.append(


### PR DESCRIPTION
Hello 😄 
I'm using Just HTTP client in my product, but I found some problem.

I tried to scrape Slack web site with Just.
In particular, I attempted to send the following request to Slack, and it failed.

```swift
var files: [String: HTTPFile] = [:]
files["name"] = .text("name", "name"", nil)
files["crumb"] = .text("crumb", "xxxxxx", nil)
files["mode"] = .text("mode", "data", nil)
files["add"] = .text("add", "1", nil)
files["img"] = .data("emoji.png", data, "image/png")

Just.post("https://my-team.slack.com/customize/emoji", files: files)
```

I was in great trouble, trial and error, and I found out that the cause is as follows.

```
let dispose = "Content-Disposition: form-data; name=\"\(k)\"; filename=\"\(filename)\"\r\n"
```

`Content-Disposition` header contained `filename` filed was not accepted at Slack.
So that, I've patched like this PR, and it works.

Thank you.
