### PR TITLE
Fix more warnings

### DIFF
--- a/Sources/Just/Just.swift
+++ b/Sources/Just/Just.swift
@@ -231,15 +231,15 @@ public final class HTTPResult : NSObject {
       // although a link without a rel is valid, there's no way to reference it.
       if linkComponents.count > 1 {
         let url = linkComponents.first!
-        let start = url.characters.index(url.startIndex, offsetBy: 1)
-        let end = url.characters.index(url.endIndex, offsetBy: -1)
+        let start = url.index(url.startIndex, offsetBy: 1)
+        let end = url.index(url.endIndex, offsetBy: -1)
         let urlRange = start..<end
-        var link: [String: String] = ["url": String(url.characters[urlRange])]
+        var link: [String: String] = ["url": String(url[urlRange])]
         linkComponents.dropFirst().forEach { s in
-          if let equalIndex = s.characters.index(of: "=") {
-            let componentKey = String(s.characters[s.startIndex..<equalIndex])
+          if let equalIndex = s.index(of: "=") {
+            let componentKey = String(s[s.startIndex..<equalIndex])
             let range = s.index(equalIndex, offsetBy: 1)..<s.endIndex
-            let value = s.characters[range]
+            let value = s[range]
             if value.first == "\"" && value.last == "\"" {
               let start = value.index(value.startIndex, offsetBy: 1)
               let end = value.index(value.endIndex, offsetBy: -1)
@@ -888,7 +888,7 @@ public final class HTTP: NSObject, URLSessionDelegate, JustAdaptor {
     if var urlComponents = url.urlComponents {
       let queryString = query(params)
 
-      if queryString.characters.count > 0 {
+      if queryString.count > 0 {
         urlComponents.percentEncodedQuery = queryString
       }
 


### PR DESCRIPTION
This fixes a couple of more warnings that cropped up in Xcode 9.1, particularly in regards to the deprecation of `String.characters`.