### PR TITLE
Remove references to Quick/Nimble

### DIFF
--- a/Just.xcodeproj/project.xcworkspace/xcshareddata/Just.xcscmblueprint
+++ b/Just.xcodeproj/project.xcworkspace/xcshareddata/Just.xcscmblueprint
@@ -9,7 +9,6 @@
   },
   "DVTSourceControlWorkspaceBlueprintIdentifierKey" : "22CD5913-486D-4C5D-AB51-76B7669E8A43",
   "DVTSourceControlWorkspaceBlueprintWorkingCopyPathsKey" : {
-    "95438028B10BBB846574013D29F154A00556A9D1" : "Just\/Externals\/Quick\/Externals\/Nimble\/",
     "BC949C044609264A7DE78DBBB5DCDDF5E033DADA" : "Just\/"
   },
   "DVTSourceControlWorkspaceBlueprintNameKey" : "Just",
@@ -17,7 +16,6 @@
   "DVTSourceControlWorkspaceBlueprintRelativePathToProjectKey" : "Just.xcodeproj",
   "DVTSourceControlWorkspaceBlueprintRemoteRepositoriesKey" : [
     {
-      "DVTSourceControlWorkspaceBlueprintRemoteRepositoryURLKey" : "https:\/\/github.com\/Quick\/Nimble.git",
       "DVTSourceControlWorkspaceBlueprintRemoteRepositorySystemKey" : "com.apple.dt.Xcode.sourcecontrol.Git",
       "DVTSourceControlWorkspaceBlueprintRemoteRepositoryIdentifierKey" : "95438028B10BBB846574013D29F154A00556A9D1"
     },


### PR DESCRIPTION
This PR removes two references to (the unused?) testing framework Quick/Nimble.

These references would cause Carthage to fail building Just on systems where Xcode 8 never had been installed:

```
=== CLEAN TARGET Quick-iOS OF PROJECT Quick WITH CONFIGURATION Release ===

Check dependencies
The “Swift Language Version” (SWIFT_VERSION) build setting must be set to a supported value for targets which use Swift. This setting can be set in the build settings editor.
The “Swift Language Version” (SWIFT_VERSION) build setting must be set to a supported value for targets which use Swift. This setting can be set in the build settings editor.

** CLEAN FAILED **


The following build commands failed:
	Check dependencies
(1 failure)
=== BUILD TARGET Quick-iOS OF PROJECT Quick WITH CONFIGURATION Release ===

Check dependencies
The “Swift Language Version” (SWIFT_VERSION) build setting must be set to a supported value for targets which use Swift. This setting can be set in the build settings editor.
The “Swift Language Version” (SWIFT_VERSION) build setting must be set to a supported value for targets which use Swift. This setting can be set in the build settings editor.

** BUILD FAILED **


The following build commands failed:
	Check dependencies
```